### PR TITLE
Return from symbol

### DIFF
--- a/lsp/init.lua
+++ b/lsp/init.lua
@@ -383,6 +383,10 @@ end
 ---Open a document location returned by LSP
 ---@param location table
 function lsp.goto_location(location)
+  local source_line, source_col = core.active_view.doc:get_selection()
+  if not core.active_view.doc.lsp_stack then core.active_view.doc.lsp_stack = {} end
+  table.insert(core.active_view.doc.lsp_stack, {line = source_line, col = source_col})
+
   core.root_view:open_doc(
     core.open_doc(
       common.home_expand(
@@ -394,6 +398,15 @@ function lsp.goto_location(location)
     location.range or location.targetRange
   )
   core.active_view.doc:set_selection(line1, col1, line1, col1)
+end
+
+function lsp.go_back()
+  if core.active_view.doc.lsp_stack then
+    local last = table.remove(core.active_view.doc.lsp_stack)
+    if last then
+      core.active_view.doc:set_selection(last.line, last.col, last.line, last.col)
+    end
+  end
 end
 
 lsp.get_location_preview = get_location_preview
@@ -2105,6 +2118,10 @@ command.add("core.docview", {
     end
     lsp.toggle_diagnostics()
   end,
+
+  ["lsp:go-back"] = function()
+    lsp.go_back()
+  end
 })
 
 --
@@ -2125,6 +2142,7 @@ keymap.add {
   ["alt+shift+e"]       = "lsp:toggle-diagnostics",
   ["alt+c"]             = "lsp:view-call-hierarchy",
   ["alt+r"]             = "lsp:rename-symbol",
+  ["alt+z"]             = "lsp:go-back",
 }
 
 --


### PR DESCRIPTION
This PR implements a function that allows going back to where the cursor was _before_ going to a symbol. Personally I think this is quite convenient for going back and forth through a call-stack.

For now, I only have a very rudimentary implementation. Some things I'm looking for feedback/suggestions on are:

- working across files (should it close the newly opened file? Keep it open? Currently it does not work across files at all)
- handling updated code elsewhere (e.g. line numbers shifting around; not sure how I could deal with that)
- command naming and keyboard shortcuts
- general code clarity